### PR TITLE
Version sin restriccion de cambio de fecha

### DIFF
--- a/Core/Model/FacturaCliente.php
+++ b/Core/Model/FacturaCliente.php
@@ -152,33 +152,6 @@ class FacturaCliente extends Base\SalesDocument
             return true;
         }
 
-        /// prevent form using old dates
-        $numColumn = \strtolower(\FS_DB_TYPE) == 'postgresql' ? 'CAST(numero as integer)' : 'CAST(numero as unsigned)';
-        $whereOld = [
-            new DataBaseWhere('codejercicio', $this->codejercicio),
-            new DataBaseWhere('codserie', $this->codserie),
-            new DataBaseWhere($numColumn, (int) $this->numero, '<')
-        ];
-        foreach ($this->all($whereOld, ['fecha' => 'DESC'], 0, 1) as $old) {
-            if (\strtotime($old->fecha) > \strtotime($this->fecha)) {
-                $this->toolBox()->i18nLog()->error('invalid-date-there-are-invoices-after', ['%date%' => $this->fecha]);
-                return false;
-            }
-        }
-
-        /// prevent the use of too new dates
-        $whereNew = [
-            new DataBaseWhere('codejercicio', $this->codejercicio),
-            new DataBaseWhere('codserie', $this->codserie),
-            new DataBaseWhere($numColumn, (int) $this->numero, '>')
-        ];
-        foreach ($this->all($whereNew, ['fecha' => 'ASC'], 0, 1) as $old) {
-            if (\strtotime($old->fecha) < \strtotime($this->fecha)) {
-                $this->toolBox()->i18nLog()->error('invalid-date-there-are-invoices-before', ['%date%' => $this->fecha]);
-                return false;
-            }
-        }
-
         return true;
     }
 


### PR DESCRIPTION
Se eliminan las restricciones del modelo facturacliente, para que permita guardar una factura con fecha de antes de la fecha de la factura anterior.